### PR TITLE
Extend inferred type for objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,9 +16,15 @@ declare type BuilderFields<T> = T extends object
   : T;
 
 declare type GenerateItem<T> = T extends {
+  type: "list";
   subFields: infer S extends readonly any[];
 }
   ? GenerateItems<S>[]
+  : T extends {
+      type: "object";
+      subFields: infer S extends readonly any[];
+    }
+  ? GenerateItems<S>
   : T extends { type: infer Type extends string }
   ? Type extends "string"
     ? T extends { enum: infer SE extends readonly string[] }


### PR DESCRIPTION
**Definition of problem**
Builder support 2 inputs which supports subFields. They are list and objects. **List** is array of objects but **object** is just object with properties defined in subFields. Current solution supports just **list** which causes error while using **object** type.

**Solution**
Differentiate list and object types.